### PR TITLE
Fix build_result check

### DIFF
--- a/jenkins/job_client.rb
+++ b/jenkins/job_client.rb
@@ -111,12 +111,13 @@ module Jenkins
           fail!('JOB ABORTED')
         end
       end
+
       if build_result == 'SUCCESS'
           puts 'DDL validation with SUCCESS status!'
       elsif timeout_countdown == 0
           fail!("JOB FOLLOW TIMED OUT (After #{job_timeout} seconds)")
       else
-        puts "DDL validation with #{build_result} status."
+        puts "DDL validation with '#{build_result}' status."
         begin
             log_response = perform_request(job_log_url, :get)
             puts log_response.body.force_encoding('utf-8')

--- a/jenkins/job_client.rb
+++ b/jenkins/job_client.rb
@@ -97,7 +97,7 @@ module Jenkins
       build_response = nil
       build_result = nil
       timeout_countdown = job_timeout
-      while build_result.nil? and timeout_countdown > 0
+      while (build_result.nil? || build_result.empty?) and timeout_countdown > 0
         begin
             build_response = perform_request(job_progress_url, :get)
             result = JSON.parse(build_response)['result']
@@ -105,7 +105,7 @@ module Jenkins
         rescue
             # "NOOP"
         end
-        if build_result.nil?
+        if (build_result.nil? || build_result.empty?)
             timeout_countdown = timeout_countdown - sleep(INTERVAL_SECONDS)
         elsif build_result == 'ABORTED'
           fail!('JOB ABORTED')

--- a/jenkins/job_client.rb
+++ b/jenkins/job_client.rb
@@ -102,6 +102,7 @@ module Jenkins
             build_response = perform_request(job_progress_url, :get)
             result = JSON.parse(build_response)['result']
             build_result = result || build_result
+            puts JSON.pretty_generate(JSON.parse(build_response))
         rescue
             # "NOOP"
         end


### PR DESCRIPTION
Sometimes the build_result for a successful build comes empty. Example:

![image](https://user-images.githubusercontent.com/597063/143222975-87572952-0b1c-4cc3-a1a3-3e113d41c5a8.png)
https://github.com/intellum/exceed/runs/4310247323?check_suite_focus=true

This PR is an attempt to fix this issue